### PR TITLE
コンパイルするソースの指定方法を変更

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,12 @@
 find_package(Boost COMPONENTS program_options REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
-aux_source_directory(. SRC_LIST)
+add_executable(${PROJECT_NAME}
+    MailAddress.cpp
+    Subdomain.cpp
+    main.cpp
+    )
 
-add_executable(${PROJECT_NAME} ${SRC_LIST})
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,6 @@ include(GoogleTest)
 
 project(${PROJECT_NAME}-test)
 
-aux_source_directory(. SRC_LIST)
-
 set(GOOGLETEST_ROOT gtest/googletest CACHE STRING "Google Test source root")
 
 include_directories(SYSTEM
@@ -22,7 +20,9 @@ endforeach()
 
 add_library(gtest ${GOOGLETEST_SOURCES})
 
-add_executable(${PROJECT_NAME} ${SRC_LIST})
+add_executable(${PROJECT_NAME}
+    test.cpp
+    )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 target_link_libraries(${PROJECT_NAME} gtest)


### PR DESCRIPTION
`aux_source_directory`を使う方法は非推奨