### PR TITLE
テストをリファクタリング

### DIFF
--- a/test/MailAddressTest.cpp
+++ b/test/MailAddressTest.cpp
@@ -6,9 +6,9 @@ namespace
 
 TEST(MailAddressTest, Method_get)
 {
-  MailAddress ma("foo", "ajt", "example.co.jp");
+  MailAddress sut("foo", "ajt", "example.co.jp");
 
-  EXPECT_EQ(ma.get(), "foo@ajt.example.co.jp");
+  EXPECT_EQ(sut.get(), "foo@ajt.example.co.jp");
 }
 
 }  // anonymous namespace

--- a/test/ProgramOptionsTest.cpp
+++ b/test/ProgramOptionsTest.cpp
@@ -9,13 +9,13 @@ TEST(ProgramOptionsTest, Help)
 {
   std::array<char*, 2> argv({"hash_subdomain",
                              "--help"});
-  ProgramOptions po(argv.size(), argv.data());
+  ProgramOptions sut(argv.size(), argv.data());
 
-  EXPECT_TRUE(po.hasHelp());
-  EXPECT_FALSE(po.helpLines().empty());
-  EXPECT_EQ(po.length(), 1);
-  EXPECT_TRUE(po.user().empty());
-  EXPECT_TRUE(po.domain().empty());
+  EXPECT_TRUE(sut.hasHelp());
+  EXPECT_FALSE(sut.helpLines().empty());
+  EXPECT_EQ(sut.length(), 1);
+  EXPECT_TRUE(sut.user().empty());
+  EXPECT_TRUE(sut.domain().empty());
 }
 
 TEST(ProgramOptionsTest, ArgumentType_1)
@@ -24,26 +24,26 @@ TEST(ProgramOptionsTest, ArgumentType_1)
                              "--length", "3",
                              "--user",   "foo",
                              "--domain", "example.co.jp"});
-  ProgramOptions po(argv.size(), argv.data());
+  ProgramOptions sut(argv.size(), argv.data());
 
-  EXPECT_FALSE(po.hasHelp());
-  EXPECT_TRUE(po.helpLines().empty());
-  EXPECT_EQ(po.length(), 3);
-  EXPECT_EQ(po.user(), "foo");
-  EXPECT_EQ(po.domain(), "example.co.jp");
+  EXPECT_FALSE(sut.hasHelp());
+  EXPECT_TRUE(sut.helpLines().empty());
+  EXPECT_EQ(sut.length(), 3);
+  EXPECT_EQ(sut.user(), "foo");
+  EXPECT_EQ(sut.domain(), "example.co.jp");
 }
 
 TEST(ProgramOptionsTest, ArgumentType_2)
 {
   std::array<char*, 3> argv({"hash_subdomain",
                              "--length", "4"});
-  ProgramOptions po(argv.size(), argv.data());
+  ProgramOptions sut(argv.size(), argv.data());
 
-  EXPECT_FALSE(po.hasHelp());
-  EXPECT_TRUE(po.helpLines().empty());
-  EXPECT_EQ(po.length(), 4);
-  EXPECT_TRUE(po.user().empty());
-  EXPECT_TRUE(po.domain().empty());
+  EXPECT_FALSE(sut.hasHelp());
+  EXPECT_TRUE(sut.helpLines().empty());
+  EXPECT_EQ(sut.length(), 4);
+  EXPECT_TRUE(sut.user().empty());
+  EXPECT_TRUE(sut.domain().empty());
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
テスト対象オブジェクトの変数名を`sut`に統一