### PR TITLE
Subdomainクラスをテンプレート化

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ add_executable(${PROJECT_NAME}
     Hash.cpp
     MailAddress.cpp
     ProgramOptions.cpp
-    Subdomain.cpp
+    Utils.cpp
     main.cpp
     )
 

--- a/src/Hash.hpp
+++ b/src/Hash.hpp
@@ -9,9 +9,9 @@ class Hash
 {
 public:
   Hash(void) =default;
-  virtual ~Hash(void) =default;
+  ~Hash(void) =default;
 
-  virtual std::size_t hash(const std::string& text, std::size_t max = std::numeric_limits<std::size_t>::max()) const;
+  std::size_t hash(const std::string& text, std::size_t max = std::numeric_limits<std::size_t>::max()) const;
 };
 
 #endif  // HASH_H

--- a/src/Subdomain.hpp
+++ b/src/Subdomain.hpp
@@ -1,18 +1,34 @@
 #ifndef SUBDOMAIN_H
 #define SUBDOMAIN_H
 
+#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <string>
+#include "Utils.hpp"
 
-class Hash;
-
+template <typename Hash>
 class Subdomain
 {
 public:
-  Subdomain(std::shared_ptr<Hash> hash, const std::string& domain, std::size_t length);
+  Subdomain(std::shared_ptr<Hash> hash, const std::string& domain, std::size_t length)
+    : hash_(hash)
+    , domain_(domain)
+    , length_(length)
+  {
+  }
 
-  std::string get(void) const;
+  std::string get(void) const
+  {
+    if (length_) {
+      std::size_t total = std::pow(26, length_);
+      std::size_t hash = hash_->hash(domain_, total);
+
+      return ::get_subdomain(hash, total);
+    } else {
+      return "";
+    }
+  }
 
 private:
   std::shared_ptr<Hash> hash_;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,17 +1,11 @@
-#include "Subdomain.hpp"
-#include <cmath>
 #include <cstddef>
-#include <memory>
 #include <string>
-#include "Hash.hpp"
+#include "Utils.hpp"
 
 constexpr char kCharacters[] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
                                 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
                                 'u', 'v', 'w', 'x', 'y', 'z'};
 constexpr std::size_t kSize = sizeof(kCharacters) / sizeof(char);
-
-namespace
-{
 
 std::string get_character(std::size_t value, std::size_t current)
 {
@@ -32,23 +26,7 @@ std::string get_subdomain(std::size_t hash, std::size_t total)
   return get_character(hash, total);
 }
 
-}  // anonymous namespace
-
-Subdomain::Subdomain(std::shared_ptr<Hash> hash, const std::string& domain, std::size_t length)
-  : hash_(hash)
-  , domain_(domain)
-  , length_(length)
+std::size_t get_size(void)
 {
-}
-
-std::string Subdomain::get(void) const
-{
-  if (length_) {
-    std::size_t total = pow(kSize, length_);
-    std::size_t hash = hash_->hash(domain_, total);
-
-    return get_subdomain(hash, total);
-  } else {
-    return "";
-  }
+  return kSize;
 }

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -1,0 +1,7 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+extern std::string get_subdomain(std::size_t hash, std::size_t total);
+extern std::size_t get_size(void);
+
+#endif  // UTILS_H 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char* argv[])
 
   std::shared_ptr<Hash> hash = std::make_shared<Hash>();
 
-  Subdomain subdomain(hash, text, length);
+  Subdomain<Hash> subdomain(hash, text, length);
   std::string hashedSubdomain = subdomain.get();
 
   std::cout << "hashed subdomain = " << hashedSubdomain << std::endl;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(${PROJECT_NAME}
     ../src/Hash.cpp
     ../src/MailAddress.cpp
     ../src/ProgramOptions.cpp
-    ../src/Subdomain.cpp
+    ../src/Utils.cpp
     HashTest.cpp
     MailAddressTest.cpp
     ProgramOptionsTest.cpp

--- a/test/HashMock.hpp
+++ b/test/HashMock.hpp
@@ -4,14 +4,12 @@
 #include <cstddef>
 #include <string>
 #include <gmock/gmock.h>
-#include "../src/Hash.hpp"
 
 class HashMock
-  : public Hash
 {
 public:
   HashMock(void) =default;
-  ~HashMock(void) override =default;
+  ~HashMock(void) =default;
 
   MOCK_CONST_METHOD2(hash, std::size_t(const std::string&, std::size_t));
 };

--- a/test/SubdomainTest.cpp
+++ b/test/SubdomainTest.cpp
@@ -20,7 +20,7 @@ protected:
 
 TEST_F(SubdomainTest, Method_get_ArgumentType_1)
 {
-  Subdomain sut(mock_, "example.com", 0);
+  Subdomain<HashMock> sut(mock_, "example.com", 0);
 
   EXPECT_TRUE(sut.get().empty());
 }
@@ -31,7 +31,7 @@ TEST_F(SubdomainTest, Method_get_ArgumentType_2)
     .Times(testing::AtLeast(1))
     .WillRepeatedly(testing::Return(253));
 
-  Subdomain sut(mock_, "example.com", 3);
+  Subdomain<HashMock> sut(mock_, "example.com", 3);
 
   EXPECT_EQ(sut.get(), "ajt");
 }


### PR DESCRIPTION
テスト(モック)のために具象クラス(`Hash`)のメソッドを仮想化してしまっていた．
モックを独立したクラスにすることで仮想化しなくてもよくなった．
しかし`Subdomain`クラスをテンプレートクラスにせざるをえなくなった．