### PR TITLE
ProgramOptionsクラスの仕様を変更

### DIFF
--- a/src/ProgramOptions.cpp
+++ b/src/ProgramOptions.cpp
@@ -3,10 +3,12 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
 
+using std::vector;
 using invalid_argument = std::invalid_argument;
 using ostringstream    = std::ostringstream;
 using size_t           = std::size_t;
@@ -17,7 +19,7 @@ const char* const kLengthKey = "length";
 const char* const kDomainKey = "domain";
 const char* const kUserKey   = "user";
 
-ProgramOptions::ProgramOptions(int argc, char** argv)
+ProgramOptions::ProgramOptions(const vector<const char*>& args)
   : hasHelp_(false)
   , helpLines_()
   , length_(0)
@@ -35,7 +37,7 @@ ProgramOptions::ProgramOptions(int argc, char** argv)
 
   po::variables_map vm;
   try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::store(po::parse_command_line(args.size(), args.data(), desc), vm);
   }
   catch (po::invalid_option_value& e) {
     throw invalid_argument(e.what());

--- a/src/ProgramOptions.hpp
+++ b/src/ProgramOptions.hpp
@@ -3,11 +3,12 @@
 
 #include <cstddef>
 #include <string>
+#include <vector>
 
 class ProgramOptions
 {
 public:
-  ProgramOptions(int argc, char** argv);
+  ProgramOptions(const std::vector<const char*>& args);
   ~ProgramOptions(void) =default;
 
   bool hasHelp(void) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,10 @@
+#include <algorithm>
 #include <cstddef>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <vector>
 #include "Hash.hpp"
 #include "MailAddress.hpp"
 #include "ProgramOptions.hpp"
@@ -11,9 +13,11 @@
 
 using std::cerr;
 using std::cin;
+using std::copy_n;
 using std::cout;
 using std::endl;
 using std::make_shared;
+using std::vector;
 using hash_ptr         = std::shared_ptr<Hash>;
 using invalid_argument = std::invalid_argument;
 using size_t           = std::size_t;
@@ -27,8 +31,11 @@ int main(int argc, char* argv[])
   string user;
   string domain;
 
+  vector<const char*> args(argc);
+  copy_n(argv, argc, args.begin());
+
   try {
-    ProgramOptions po(argc, argv);
+    ProgramOptions po(args);
     hasHelp   = po.hasHelp();
     helpLines = po.helpLines();
     length    = po.length();

--- a/test/ProgramOptionsTest.cpp
+++ b/test/ProgramOptionsTest.cpp
@@ -1,16 +1,19 @@
-#include <array>
 #include <stdexcept>
+#include <vector>
 #include <gtest/gtest.h>
 #include "../src/ProgramOptions.hpp"
+
+using std::vector;
+using invalid_argument = std::invalid_argument;
 
 namespace
 {
 
 TEST(ProgramOptionsTest, Help)
 {
-  std::array<char*, 2> argv({"hash_subdomain",
-                             "--help"});
-  ProgramOptions sut(argv.size(), argv.data());
+  vector<const char*> args({"hash_subdomain",
+                            "--help"});
+  ProgramOptions sut(args);
 
   EXPECT_TRUE(sut.hasHelp());
   EXPECT_FALSE(sut.helpLines().empty());
@@ -21,11 +24,11 @@ TEST(ProgramOptionsTest, Help)
 
 TEST(ProgramOptionsTest, ArgumentType_1)
 {
-  std::array<char*, 7> argv({"hash_subdomain",
-                             "--length", "3",
-                             "--user",   "foo",
-                             "--domain", "example.co.jp"});
-  ProgramOptions sut(argv.size(), argv.data());
+  vector<const char*> args({"hash_subdomain",
+                            "--length", "3",
+                            "--user",   "foo",
+                            "--domain", "example.co.jp"});
+  ProgramOptions sut(args);
 
   EXPECT_FALSE(sut.hasHelp());
   EXPECT_TRUE(sut.helpLines().empty());
@@ -36,9 +39,9 @@ TEST(ProgramOptionsTest, ArgumentType_1)
 
 TEST(ProgramOptionsTest, ArgumentType_2)
 {
-  std::array<char*, 3> argv({"hash_subdomain",
-                             "--length", "4"});
-  ProgramOptions sut(argv.size(), argv.data());
+  vector<const char*> args({"hash_subdomain",
+                            "--length", "4"});
+  ProgramOptions sut(args);
 
   EXPECT_FALSE(sut.hasHelp());
   EXPECT_TRUE(sut.helpLines().empty());
@@ -49,12 +52,13 @@ TEST(ProgramOptionsTest, ArgumentType_2)
 
 TEST(ProgramOptionsTest, InvalidOptionValueException)
 {
-  std::array<char*, 3> argv({"hash_subdomain",
-                             "--length", "foo"});
+  vector<const char*> args({"hash_subdomain",
+                            "--length", "foo"});
+
   EXPECT_THROW({
-      ProgramOptions sut(argv.size(), argv.data());
+      ProgramOptions sut(args);
     },
-    std::invalid_argument);
+    invalid_argument);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
`parse_command_line()`が`const charT* const`で受け取るため
`main()`の`argv`をそのまま渡す必要がない

テストで`argv`を組み立てる際コンパイル警告がうるさかったのを
黙らせることができた